### PR TITLE
Add simultaneous XY homing option

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -237,6 +237,10 @@ max_z_accel:
 #   This sets the maximum acceleration (in mm/s^2) of movement along
 #   the z axis. It limits the acceleration of the z stepper motor. The
 #   default is to use max_accel for max_z_accel.
+simultaneous_xy_homing: False
+#   If set to True, the X and Y axes will be homed together when both
+#   axes are included in a homing command. The default is to home each
+#   axis sequentially.
 
 # The stepper_x section is used to describe the stepper controlling
 # the X axis in a cartesian robot.
@@ -433,6 +437,10 @@ max_z_accel:
 #   This sets the maximum acceleration (in mm/s^2) of movement along
 #   the z axis. It limits the acceleration of the z stepper motor. The
 #   default is to use max_accel for max_z_accel.
+simultaneous_xy_homing: False
+#   If set to True, the X and Y axes will be homed together when both
+#   axes are included in a homing command. The default is to home each
+#   axis sequentially.
 
 # The stepper_x section is used to describe the X axis as well as the
 # stepper controlling the X+Y movement.


### PR DESCRIPTION
## Summary
- add optional simultaneous XY homing for cartesian and corexy
- document new `simultaneous_xy_homing` setting

## Testing
- `python3 scripts/test_klippy.py test/klippy/printers.test` *(fails: ModuleNotFoundError: No module named 'greenlet')*

------
https://chatgpt.com/codex/tasks/task_e_686ee1619e288326b7177a454741f269